### PR TITLE
dockerfile: Add gpg pkg to fix codecov workflows

### DIFF
--- a/Dockerfile.debian.python
+++ b/Dockerfile.debian.python
@@ -10,9 +10,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     meson gcc g++ clang pkg-config git \
     libjson-c-dev libssl-dev libkeyutils-dev libdbus-1-dev libpython3-dev \
-    pipx python3-dev swig xz-utils \
-    xz-utils \
-    lcov && \
+    pipx python3-dev swig xz-utils lcov gnupg && \
     apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The code coverage workflow of both nvme-cli and libnvme is silently failing partly because gpg is not present for importing the Codecov gpg key.
See https://github.com/linux-nvme/nvme-cli/actions/runs/11609541747/job/32326984209

At the same time clean up packages that are installed twice.