### PR TITLE
dockerfile: add Clang Static Analyzer tooling to container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ staging-dockerfiles: $(STAGING_DOCKERFILES)
 
 main/Dockerfile.%: ci-containers.yaml generate.py templates/Dockerfile.%.j2
 	@if [ "$*" = "debian" ]; then \
-		./generate.py --distro $* --bundles nvme,muon-dep,musl,coverage,coverity,docs,python --features muon --output $@; \
+		./generate.py --distro $* --bundles nvme,muon-dep,musl,coverage,analyzers,docs,python --features muon --output $@; \
 	else \
-		./generate.py --distro $* --bundles nvme,muon-dep,python --features muon --output $@; \
+		./generate.py --distro $* --bundles nvme,analyzers,python --output $@; \
 	fi
 
 staging/Dockerfile.%: ci-containers.yaml generate.py templates/Dockerfile.%.j2

--- a/ci-containers.yaml
+++ b/ci-containers.yaml
@@ -7,7 +7,7 @@
 
 base_images:
   debian: "debian:trixie-slim"
-  fedora: "fedora:43"
+  fedora: "fedora:latest"
   tumbleweed: "opensuse/tumbleweed:latest"
   alpine: "alpine:latest"
 

--- a/ci-containers.yaml
+++ b/ci-containers.yaml
@@ -56,6 +56,7 @@ bundles:
       - keyutils-devel
       - dbus-1-devel
     alpine:
+      - clang
       - gcc
       - git
       - meson
@@ -87,9 +88,15 @@ bundles:
       - pipx
       - gcovr
 
-  coverity:
+  analyzers:
     debian:
-      - file
+      - clang-tools
+    fedora:
+      - clang-analyzer
+    tumbleweed:
+      - clang-tools
+    alpine:
+      - clang-analyzer
 
   python:
     debian:

--- a/main/Dockerfile.alpine
+++ b/main/Dockerfile.alpine
@@ -12,6 +12,7 @@ ENV TZ=Europe/Berlin
 RUN apk update && \
     apk add musl-locales tzdata && \
     apk add \
+    clang \
     gcc \
     git \
     meson \
@@ -23,8 +24,7 @@ RUN apk update && \
     openssl-dev \
     keyutils-dev \
     dbus-dev \
-    curl \
-    libarchive \
+    clang-analyzer \
     python3 \
     python3-dev \
     py3-pip \
@@ -32,6 +32,5 @@ RUN apk update && \
     && apk cache clean && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
-COPY --chmod=755 bin/samu bin/muon /usr/bin
 
 WORKDIR /build

--- a/main/Dockerfile.debian
+++ b/main/Dockerfile.debian
@@ -37,7 +37,7 @@ RUN apt-get update && \
     gnupg \
     pipx \
     gcovr \
-    file \
+    clang-tools \
     python3-sphinx \
     asciidoc \
     xmlto \

--- a/main/Dockerfile.fedora
+++ b/main/Dockerfile.fedora
@@ -25,14 +25,12 @@ RUN dnf update -y && \
     keyutils-libs-devel \
     dbus-devel \
     redhat-rpm-config \
-    libcurl \
-    libarchive \
+    clang-analyzer \
     python3 \
     python3-devel \
     python3-pip \
     && dnf clean all && \
     rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*
 
-COPY --chmod=755 bin/samu bin/muon /usr/bin
 
 WORKDIR /build

--- a/main/Dockerfile.fedora
+++ b/main/Dockerfile.fedora
@@ -3,7 +3,7 @@
 # Copyright (C) 2026 Daniel Wagner, SUSE LLC
 #
 # Author: Daniel Wagner <dwagner@suse.de>
-FROM fedora:43
+FROM fedora:latest
 
 ARG TARGETPLATFORM
 ENV LANG=en_US.utf8

--- a/main/Dockerfile.tumbleweed
+++ b/main/Dockerfile.tumbleweed
@@ -27,8 +27,7 @@ RUN zypper --non-interactive refresh && \
     libopenssl-devel \
     keyutils-devel \
     dbus-1-devel \
-    libcurl4 \
-    libarchive13 \
+    clang-tools \
     python3 \
     python3-devel \
     python3-pip \
@@ -36,6 +35,5 @@ RUN zypper --non-interactive refresh && \
     && zypper clean --all && \
     rm -rf /var/cache/zypp/* /tmp/* /var/tmp/*
 
-COPY --chmod=755 bin/samu bin/muon /usr/bin
 
 WORKDIR /build

--- a/staging/Dockerfile.fedora
+++ b/staging/Dockerfile.fedora
@@ -3,7 +3,7 @@
 # Copyright (C) 2026 Daniel Wagner, SUSE LLC
 #
 # Author: Daniel Wagner <dwagner@suse.de>
-FROM fedora:43
+FROM fedora:latest
 
 ARG TARGETPLATFORM
 ENV LANG=en_US.utf8


### PR DESCRIPTION
The nvme-cli build script supports running the Clang Static Analyzer via scan-build. Add the required analyzer packages to the generated CI container images so static analysis can be executed directly inside the containers used by GitHub Actions.