### PR TITLE
build: build nvmetcli containerdisks on the runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,13 +278,17 @@ jobs:
             echo "RELEASE_VERSION=" >> $GITHUB_ENV
           fi
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - name: Install libguestfs tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            guestfs-tools guestmount python3-yaml
+
+      - name: Inject nvmetcli tools into the base cloud image
+        run: scripts/build-containerdisk.sh ${{ matrix.distro }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          buildkitd-flags: --allow-insecure-entitlement security.insecure
 
       - name: Login to ghcr.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -296,12 +300,11 @@ jobs:
       - name: Build and push nvmetcli containerDisk
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
-          context: .
+          context: nvmetcli/build
           file: nvmetcli/Dockerfile.${{ matrix.distro }}.containerdisk
           platforms: linux/amd64
           push: true
           provenance: false
-          allow: security.insecure
           tags: |
             ghcr.io/linux-nvme/nvmetcli-${{ matrix.distro }}-containerdisk:next
             ${{ env.RELEASE_VERSION && format('ghcr.io/linux-nvme/nvmetcli-{0}-containerdisk:{1}', matrix.distro, env.RELEASE_VERSION) || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nvmetcli/build/

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,6 @@ STAGING_BUILD_TARGETS := $(addprefix build-staging-,$(DISTROS))
 NVMETCLI_BUILD_TARGETS := $(addprefix build-nvmetcli-,$(NVMETCLI_DISTROS))
 NVMETCLI_CONTAINERDISK_BUILD_TARGETS := $(addprefix build-nvmetcli-containerdisk-,$(NVMETCLI_DISTROS))
 
-# Buildx builder with the security.insecure entitlement, required because the
-# containerDisk builds run virt-customize (a libguestfs appliance VM).
-INSECURE_BUILDER := ci-insecure
-
 .PHONY: all help generate build staging-build build-nvmetcli \
         build-nvmetcli-containerdisk staging-dockerfiles \
         $(BUILD_TARGETS) $(STAGING_BUILD_TARGETS) $(NVMETCLI_BUILD_TARGETS) \
@@ -90,12 +86,10 @@ $(STAGING_BUILD_TARGETS): build-staging-%: | staging/Dockerfile.%
 $(NVMETCLI_BUILD_TARGETS): build-nvmetcli-%: | nvmetcli/Dockerfile.%
 	sudo docker build -f nvmetcli/Dockerfile.$* -t ci:nvmetcli-$* .
 
-# containerDisks need virt-customize, which requires the security.insecure
-# entitlement, so build them with buildx on a dedicated builder.
+# containerDisks inject the nvmetcli tools into the base cloud image on the
+# host (scripts/build-containerdisk.sh), then package the resulting qcow2 as a
+# scratch containerDisk.
 $(NVMETCLI_CONTAINERDISK_BUILD_TARGETS): build-nvmetcli-containerdisk-%: | nvmetcli/Dockerfile.%.containerdisk
-	sudo docker buildx inspect $(INSECURE_BUILDER) >/dev/null 2>&1 || \
-		sudo docker buildx create --name $(INSECURE_BUILDER) \
-			--buildkitd-flags '--allow-insecure-entitlement security.insecure' >/dev/null
-	sudo docker buildx build --builder $(INSECURE_BUILDER) \
-		--allow security.insecure --load \
-		-f nvmetcli/Dockerfile.$*.containerdisk -t ci:nvmetcli-$*-containerdisk .
+	DOCKER="sudo docker" scripts/build-containerdisk.sh $*
+	sudo docker build -f nvmetcli/Dockerfile.$*.containerdisk \
+		-t ci:nvmetcli-$*-containerdisk nvmetcli/build

--- a/ci-containers.yaml
+++ b/ci-containers.yaml
@@ -16,8 +16,6 @@ containerdisk_base_images:
   fedora: "quay.io/containerdisks/fedora:44"
   tumbleweed: "quay.io/containerdisks/opensuse-tumbleweed:1.0.0"
 
-containerdisk_builder_image: "fedora:latest"
-
 bundles:
   nvme:
     debian:

--- a/generate.py
+++ b/generate.py
@@ -64,6 +64,11 @@ def main():
     parser.add_argument("--base-images", default="base_images",
                         help="Config key holding the distro->base image map "
                              "(e.g. containerdisk_base_images)")
+    parser.add_argument("--print-packages", action="store_true",
+                        help="Print the resolved package list (comma "
+                             "separated) and exit")
+    parser.add_argument("--print-base-image", action="store_true",
+                        help="Print the resolved base image and exit")
     parser.add_argument("--output", default=None)
 
     args = parser.parse_args()
@@ -75,6 +80,13 @@ def main():
     packages = build_package_list(config, args.distro, bundle_list)
 
     base_image = config[args.base_images][args.distro]
+
+    if args.print_packages:
+        print(",".join(packages))
+        return
+    if args.print_base_image:
+        print(base_image)
+        return
 
     env = Environment(
         loader=FileSystemLoader(TEMPLATE_DIR),

--- a/nvmetcli/Dockerfile.debian.containerdisk
+++ b/nvmetcli/Dockerfile.debian.containerdisk
@@ -4,37 +4,13 @@
 #
 # Author: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>
 #
-# KubeVirt containerDisk: a bootable debian cloud image with the nvmetcli
-# tools pre-installed. Unlike a plain container image, a containerDisk holds a
-# bootable VM disk (a qcow2 in /disk, owned by UID 107 == qemu) that KubeVirt
-# boots as the VM root volume. The tools are injected into the base cloud qcow2
-# with virt-customize, then the disk is re-packaged on a scratch image.
+# KubeVirt containerDisk for debian: packages a bootable cloud qcow2 that
+# already has the nvmetcli tools injected. The tools are injected on the host
+# by scripts/build-containerdisk.sh (which mounts the image with libguestfs and
+# runs the guest package manager in a chroot), not inside this build: the
+# libguestfs appliance has no working network on hosted CI runners.
 #
-# virt-customize runs a libguestfs appliance VM, so building requires the
-# BuildKit "security.insecure" entitlement:
-#   docker buildx build --allow security.insecure ...
-# using a builder started with "--allow-insecure-entitlement security.insecure".
-
-# Base cloud-image containerDisk we customize (scratch image holding the qcow2).
-FROM quay.io/containerdisks/debian:13 AS base
-
-# Builder stage: guestfs-tools provides virt-customize; the kernel package is
-# needed for the libguestfs supermin appliance.
-FROM fedora:latest AS builder
-RUN dnf install -y guestfs-tools qemu-img kernel && dnf clean all
-
-# Pull the bootable qcow2 out of the base containerDisk (a single file in /disk).
-COPY --from=base /disk/ /input/
-RUN mv "$(find /input -maxdepth 1 -type f | head -n1)" /disk.qcow2
-
-# Inject the nvmetcli tools into the guest. LIBGUESTFS_BACKEND=direct runs qemu
-# directly and falls back to TCG when /dev/kvm is unavailable (e.g. on
-# GitHub-hosted runners). The guest distro/package manager is auto-detected.
-ENV LIBGUESTFS_BACKEND=direct
-RUN --security=insecure \
-    virt-customize -a /disk.qcow2 \
-    --install git,make,python3-configshell-fb,python3-dev,python3-nose2
-
-# Final containerDisk image: nothing but the disk, per the KubeVirt spec.
+# A containerDisk is just the VM disk in /disk, owned by UID 107 (qemu). The
+# build context is the directory holding the customized qcow2 (nvmetcli/build).
 FROM scratch
-COPY --from=builder --chown=107:107 /disk.qcow2 /disk/debian-nvmetcli.qcow2
+COPY --chown=107:107 debian-nvmetcli.qcow2 /disk/debian-nvmetcli.qcow2

--- a/nvmetcli/Dockerfile.fedora.containerdisk
+++ b/nvmetcli/Dockerfile.fedora.containerdisk
@@ -4,38 +4,13 @@
 #
 # Author: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>
 #
-# KubeVirt containerDisk: a bootable fedora cloud image with the nvmetcli
-# tools pre-installed. Unlike a plain container image, a containerDisk holds a
-# bootable VM disk (a qcow2 in /disk, owned by UID 107 == qemu) that KubeVirt
-# boots as the VM root volume. The tools are injected into the base cloud qcow2
-# with virt-customize, then the disk is re-packaged on a scratch image.
+# KubeVirt containerDisk for fedora: packages a bootable cloud qcow2 that
+# already has the nvmetcli tools injected. The tools are injected on the host
+# by scripts/build-containerdisk.sh (which mounts the image with libguestfs and
+# runs the guest package manager in a chroot), not inside this build: the
+# libguestfs appliance has no working network on hosted CI runners.
 #
-# virt-customize runs a libguestfs appliance VM, so building requires the
-# BuildKit "security.insecure" entitlement:
-#   docker buildx build --allow security.insecure ...
-# using a builder started with "--allow-insecure-entitlement security.insecure".
-
-# Base cloud-image containerDisk we customize (scratch image holding the qcow2).
-FROM quay.io/containerdisks/fedora:44 AS base
-
-# Builder stage: guestfs-tools provides virt-customize; the kernel package is
-# needed for the libguestfs supermin appliance.
-FROM fedora:latest AS builder
-RUN dnf install -y guestfs-tools qemu-img kernel && dnf clean all
-
-# Pull the bootable qcow2 out of the base containerDisk (a single file in /disk).
-COPY --from=base /disk/ /input/
-RUN mv "$(find /input -maxdepth 1 -type f | head -n1)" /disk.qcow2
-
-# Inject the nvmetcli tools into the guest. LIBGUESTFS_BACKEND=direct runs qemu
-# directly and falls back to TCG when /dev/kvm is unavailable (e.g. on
-# GitHub-hosted runners). The guest distro/package manager is auto-detected.
-ENV LIBGUESTFS_BACKEND=direct
-RUN --security=insecure \
-    virt-customize -a /disk.qcow2 \
-    --selinux-relabel \
-    --install git,make,python3-configshell,python3-kmod,python3-devel,python3-nose2
-
-# Final containerDisk image: nothing but the disk, per the KubeVirt spec.
+# A containerDisk is just the VM disk in /disk, owned by UID 107 (qemu). The
+# build context is the directory holding the customized qcow2 (nvmetcli/build).
 FROM scratch
-COPY --from=builder --chown=107:107 /disk.qcow2 /disk/fedora-nvmetcli.qcow2
+COPY --chown=107:107 fedora-nvmetcli.qcow2 /disk/fedora-nvmetcli.qcow2

--- a/nvmetcli/Dockerfile.tumbleweed.containerdisk
+++ b/nvmetcli/Dockerfile.tumbleweed.containerdisk
@@ -4,37 +4,13 @@
 #
 # Author: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>
 #
-# KubeVirt containerDisk: a bootable tumbleweed cloud image with the nvmetcli
-# tools pre-installed. Unlike a plain container image, a containerDisk holds a
-# bootable VM disk (a qcow2 in /disk, owned by UID 107 == qemu) that KubeVirt
-# boots as the VM root volume. The tools are injected into the base cloud qcow2
-# with virt-customize, then the disk is re-packaged on a scratch image.
+# KubeVirt containerDisk for tumbleweed: packages a bootable cloud qcow2 that
+# already has the nvmetcli tools injected. The tools are injected on the host
+# by scripts/build-containerdisk.sh (which mounts the image with libguestfs and
+# runs the guest package manager in a chroot), not inside this build: the
+# libguestfs appliance has no working network on hosted CI runners.
 #
-# virt-customize runs a libguestfs appliance VM, so building requires the
-# BuildKit "security.insecure" entitlement:
-#   docker buildx build --allow security.insecure ...
-# using a builder started with "--allow-insecure-entitlement security.insecure".
-
-# Base cloud-image containerDisk we customize (scratch image holding the qcow2).
-FROM quay.io/containerdisks/opensuse-tumbleweed:1.0.0 AS base
-
-# Builder stage: guestfs-tools provides virt-customize; the kernel package is
-# needed for the libguestfs supermin appliance.
-FROM fedora:latest AS builder
-RUN dnf install -y guestfs-tools qemu-img kernel && dnf clean all
-
-# Pull the bootable qcow2 out of the base containerDisk (a single file in /disk).
-COPY --from=base /disk/ /input/
-RUN mv "$(find /input -maxdepth 1 -type f | head -n1)" /disk.qcow2
-
-# Inject the nvmetcli tools into the guest. LIBGUESTFS_BACKEND=direct runs qemu
-# directly and falls back to TCG when /dev/kvm is unavailable (e.g. on
-# GitHub-hosted runners). The guest distro/package manager is auto-detected.
-ENV LIBGUESTFS_BACKEND=direct
-RUN --security=insecure \
-    virt-customize -a /disk.qcow2 \
-    --install git,make,python3-configshell-fb,python3-devel,python3-nose2
-
-# Final containerDisk image: nothing but the disk, per the KubeVirt spec.
+# A containerDisk is just the VM disk in /disk, owned by UID 107 (qemu). The
+# build context is the directory holding the customized qcow2 (nvmetcli/build).
 FROM scratch
-COPY --from=builder --chown=107:107 /disk.qcow2 /disk/tumbleweed-nvmetcli.qcow2
+COPY --chown=107:107 tumbleweed-nvmetcli.qcow2 /disk/tumbleweed-nvmetcli.qcow2

--- a/scripts/build-containerdisk.sh
+++ b/scripts/build-containerdisk.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2026 Western Digital Corporation or its affiliates.
+#
+# Author: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>
+#
+# Build the customized nvmetcli containerDisk qcow2 for a distro: extract the
+# base cloud image out of its KubeVirt containerDisk and inject the nvmetcli
+# tools. Produces nvmetcli/build/<distro>-nvmetcli.qcow2, which
+# nvmetcli/Dockerfile.<distro>.containerdisk then packages as a scratch
+# containerDisk.
+#
+# The tools are injected by mounting the guest filesystem with libguestfs
+# (guestmount, which needs no network) and running the guest's own package
+# manager in a chroot that borrows the *host's* network. We deliberately do
+# NOT use `virt-customize --install`: on hosted CI runners the libguestfs
+# appliance never gets working networking.
+#
+# Needs guestmount (libguestfs) and runs mount/chroot/guestmount under sudo:
+# guestmount as root can read the mode-0600 host kernel and use /dev/kvm. The
+# container runtime can be overridden, e.g. DOCKER="sudo docker".
+
+set -euo pipefail
+
+distro="${1:?usage: build-containerdisk.sh <distro>}"
+DOCKER="${DOCKER:-docker}"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+base_image="$(./generate.py --distro "$distro" --bundles nvmetcli \
+    --base-images containerdisk_base_images --print-base-image)"
+packages="$(./generate.py --distro "$distro" --bundles nvmetcli --print-packages)"
+
+builddir="nvmetcli/build"
+workdir="${builddir}/.extract-${distro}"
+qcow="${builddir}/${distro}-nvmetcli.qcow2"
+mnt="$(mktemp -d)"
+
+# Extract the bootable qcow2 from the base containerDisk. It is a scratch image
+# holding the disk in /disk, so give `docker create` a dummy command (the
+# container is never started).
+rm -rf "$workdir"
+mkdir -p "$workdir"
+echo "Extracting base disk from ${base_image} ..."
+cid="$($DOCKER create "$base_image" nvmetcli-extract)"
+$DOCKER cp "${cid}:/disk/." "$workdir/"
+$DOCKER rm "$cid" >/dev/null
+
+src="$(find "$workdir" -maxdepth 1 -type f | head -n1)"
+if [ -z "$src" ]; then
+    echo "error: no disk image found in ${base_image}:/disk" >&2
+    exit 1
+fi
+
+# Package-manager invocation per distro, mirroring what `virt-customize
+# --install` runs so the resulting image is equivalent.
+case "$distro" in
+    debian)
+        # --force-unsafe-io skips dpkg's per-file fsync (needless durability
+        # that is very slow over the guestmount FUSE); APT::Sandbox::User=root
+        # avoids apt trying to drop to the _apt user, which cannot read the
+        # root-only FUSE mount. Neither changes which packages get installed.
+        install_cmd="export DEBIAN_FRONTEND=noninteractive
+apt_opts='-q -y -o APT::Sandbox::User=root -o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-unsafe-io'
+apt-get \$apt_opts update
+apt-get \$apt_opts install ${packages//,/ }"
+        ;;
+    fedora)
+        install_cmd="dnf -y install ${packages//,/ }"
+        ;;
+    tumbleweed)
+        install_cmd="zypper -n in -l ${packages//,/ }"
+        ;;
+    *)
+        echo "error: unknown distro '${distro}'" >&2
+        exit 1
+        ;;
+esac
+
+# A bind/pseudo mount can momentarily report "busy" right after the chroot
+# exits. Retry a few times and fall back to a lazy unmount so cleanup never
+# aborts the build.
+umount_retry() {
+    local target="$1"
+    for _ in 1 2 3; do
+        sudo umount "$target" 2>/dev/null && return 0
+        sleep 1
+    done
+    sudo umount -l "$target" 2>/dev/null || true
+}
+
+mounted=0
+cleanup() {
+    set +e
+    if [ "$mounted" = 1 ]; then
+        for d in dev proc sys; do
+            umount_retry "$mnt/$d"
+        done
+        for _ in 1 2 3 4 5; do
+            sudo guestunmount "$mnt" 2>/dev/null && break
+            sleep 1
+        done
+    fi
+    rmdir "$mnt" 2>/dev/null
+}
+trap cleanup EXIT
+
+echo "Injecting nvmetcli tools into ${distro}: ${packages}"
+sudo guestmount -a "$src" -i --rw "$mnt"
+mounted=1
+sudo mount --bind /dev "$mnt/dev"
+sudo mount -t proc proc "$mnt/proc"
+sudo mount -t sysfs sys "$mnt/sys"
+
+if sudo test -e "$mnt/etc/resolv.conf" || sudo test -L "$mnt/etc/resolv.conf"; then
+    sudo mv "$mnt/etc/resolv.conf" "$mnt/etc/resolv.conf.ci-orig"
+fi
+if [ -e /run/systemd/resolve/resolv.conf ]; then
+    sudo cp --remove-destination /run/systemd/resolve/resolv.conf "$mnt/etc/resolv.conf"
+else
+    sudo cp --remove-destination /etc/resolv.conf "$mnt/etc/resolv.conf"
+fi
+
+sudo chroot "$mnt" /bin/bash -c "$install_cmd"
+
+sudo rm -f "$mnt/etc/resolv.conf"
+if sudo test -e "$mnt/etc/resolv.conf.ci-orig" || sudo test -L "$mnt/etc/resolv.conf.ci-orig"; then
+    sudo mv "$mnt/etc/resolv.conf.ci-orig" "$mnt/etc/resolv.conf"
+fi
+
+# Fedora boots SELinux enforcing. The files we just wrote in the chroot are
+# unlabelled, so schedule a relabel on first boot (equivalent to what
+# virt-customize --selinux-relabel arranges).
+if [ "$distro" = "fedora" ]; then
+    sudo touch "$mnt/.autorelabel"
+fi
+
+for d in dev proc sys; do
+    umount_retry "$mnt/$d"
+done
+for _ in 1 2 3 4 5; do
+    sudo guestunmount "$mnt" && break
+    sleep 1
+done
+mounted=0
+
+mkdir -p "$builddir"
+sudo mv -f "$src" "$qcow"
+sudo chown "$(id -u):$(id -g)" "$qcow"
+sudo rm -rf "$workdir"
+echo "Created ${qcow}"

--- a/templates/Dockerfile.containerdisk.j2
+++ b/templates/Dockerfile.containerdisk.j2
@@ -4,40 +4,13 @@
 #
 # Author: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>
 #
-# KubeVirt containerDisk: a bootable {{ distro }} cloud image with the nvmetcli
-# tools pre-installed. Unlike a plain container image, a containerDisk holds a
-# bootable VM disk (a qcow2 in /disk, owned by UID 107 == qemu) that KubeVirt
-# boots as the VM root volume. The tools are injected into the base cloud qcow2
-# with virt-customize, then the disk is re-packaged on a scratch image.
+# KubeVirt containerDisk for {{ distro }}: packages a bootable cloud qcow2 that
+# already has the nvmetcli tools injected. The tools are injected on the host
+# by scripts/build-containerdisk.sh (which mounts the image with libguestfs and
+# runs the guest package manager in a chroot), not inside this build: the
+# libguestfs appliance has no working network on hosted CI runners.
 #
-# virt-customize runs a libguestfs appliance VM, so building requires the
-# BuildKit "security.insecure" entitlement:
-#   docker buildx build --allow security.insecure ...
-# using a builder started with "--allow-insecure-entitlement security.insecure".
-
-# Base cloud-image containerDisk we customize (scratch image holding the qcow2).
-FROM {{ base_image }} AS base
-
-# Builder stage: guestfs-tools provides virt-customize; the kernel package is
-# needed for the libguestfs supermin appliance.
-FROM {{ builder_image }} AS builder
-RUN dnf install -y guestfs-tools qemu-img kernel && dnf clean all
-
-# Pull the bootable qcow2 out of the base containerDisk (a single file in /disk).
-COPY --from=base /disk/ /input/
-RUN mv "$(find /input -maxdepth 1 -type f | head -n1)" /disk.qcow2
-
-# Inject the nvmetcli tools into the guest. LIBGUESTFS_BACKEND=direct runs qemu
-# directly and falls back to TCG when /dev/kvm is unavailable (e.g. on
-# GitHub-hosted runners). The guest distro/package manager is auto-detected.
-ENV LIBGUESTFS_BACKEND=direct
-RUN --security=insecure \
-    virt-customize -a /disk.qcow2 \
-{% if distro == "fedora" %}
-    --selinux-relabel \
-{% endif %}
-    --install {{ packages | join(",") }}
-
-# Final containerDisk image: nothing but the disk, per the KubeVirt spec.
+# A containerDisk is just the VM disk in /disk, owned by UID 107 (qemu). The
+# build context is the directory holding the customized qcow2 (nvmetcli/build).
 FROM scratch
-COPY --from=builder --chown=107:107 /disk.qcow2 /disk/{{ distro }}-nvmetcli.qcow2
+COPY --chown=107:107 {{ distro }}-nvmetcli.qcow2 /disk/{{ distro }}-nvmetcli.qcow2


### PR DESCRIPTION
virt-customize injects the nvmetcli tools into the base cloud image, but running it (whether inside the container build or on the runner) fails on hosted CI runners: the libguestfs appliance never gets working networking.

Inject the tools on the runner instead (scripts/build-containerdisk.sh): mount the base image with libguestfs (guestmount, which needs no guest network) and run the guest's own package manager in a chroot that borrows the runner's network, then package the resulting qcow2 as a scratch containerDisk. This also drops the in-build BuildKit security.insecure entitlement.