### PR TITLE
containerdisk: bake the KubeVirt runner tooling into every variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,15 @@ CONTAINERDISK_VARIANTS := nvmetcli blktests
 nvmetcli_DISTROS := debian fedora tumbleweed
 blktests_DISTROS := fedora
 
+CONTAINERDISK_EXTRA_BUNDLES := kubevirt-runner
+
 # Expand the generate + build rules for one containerDisk variant ($1).
 define CONTAINERDISK_rules
 CONTAINERDISK_DOCKERFILES += $$(foreach d,$$($(1)_DISTROS),$(1)/Dockerfile.$$(d).containerdisk)
 CONTAINERDISK_BUILD_TARGETS += $$(addprefix build-$(1)-containerdisk-,$$($(1)_DISTROS))
 
 $(1)/Dockerfile.%.containerdisk: ci-containers.yaml generate.py templates/Dockerfile.containerdisk.j2
-	./generate.py --distro $$* --bundles $(1) --variant $(1) \
+	./generate.py --distro $$* --bundles $(1),$(CONTAINERDISK_EXTRA_BUNDLES) --variant $(1) \
 		--template Dockerfile.containerdisk.j2 \
 		--base-images containerdisk_base_images \
 		--output $$@

--- a/ci-containers.yaml
+++ b/ci-containers.yaml
@@ -212,6 +212,32 @@ bundles:
       - curl
       - libarchive
 
+  # Tooling every KubeVirt containerDisk needs on top of its own variant bundle.
+  kubevirt-runner:
+    debian:
+      - sudo
+      - podman
+      - jq
+      - nvme-cli
+      - sg3-utils
+      - lsscsi
+
+    fedora:
+      - sudo
+      - podman
+      - jq
+      - nvme-cli
+      - sg3_utils
+      - lsscsi
+
+    tumbleweed:
+      - sudo
+      - podman
+      - jq
+      - nvme-cli
+      - sg3_utils
+      - lsscsi
+
   nvmetcli:
     debian:
       - ca-certificates

--- a/scripts/build-containerdisk.sh
+++ b/scripts/build-containerdisk.sh
@@ -28,12 +28,27 @@ distro="${1:?usage: build-containerdisk.sh <distro> <variant>}"
 variant="${2:?usage: build-containerdisk.sh <distro> <variant>}"
 DOCKER="${DOCKER:-docker}"
 
+EXTRA_BUNDLES="${EXTRA_BUNDLES-kubevirt-runner}"
+
+libguestfs_env=()
+for _v in LIBGUESTFS_BACKEND LIBGUESTFS_HV LIBGUESTFS_DEBUG LIBGUESTFS_TRACE; do
+    if [ -n "${!_v-}" ]; then
+        libguestfs_env+=("${_v}=${!_v}")
+    fi
+done
+sudo_guestfs() { sudo env "${libguestfs_env[@]}" "$@"; }
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
-base_image="$(./generate.py --distro "$distro" --bundles "$variant" \
+bundles="$variant"
+if [ -n "$EXTRA_BUNDLES" ]; then
+    bundles="${variant},${EXTRA_BUNDLES}"
+fi
+
+base_image="$(./generate.py --distro "$distro" --bundles "$bundles" \
     --base-images containerdisk_base_images --print-base-image)"
-packages="$(./generate.py --distro "$distro" --bundles "$variant" --print-packages)"
+packages="$(./generate.py --distro "$distro" --bundles "$bundles" --print-packages)"
 
 builddir="${variant}/build"
 workdir="${builddir}/.extract-${distro}"
@@ -108,7 +123,7 @@ cleanup() {
             umount_retry "$mnt/$d"
         done
         for _ in 1 2 3 4 5; do
-            sudo guestunmount "$mnt" 2>/dev/null && break
+            sudo_guestfs guestunmount "$mnt" 2>/dev/null && break
             sleep 1
         done
     fi
@@ -117,7 +132,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Injecting ${variant} tools into ${distro}: ${packages}"
-sudo guestmount -a "$src" -i --rw "$mnt"
+sudo_guestfs guestmount -a "$src" -i --rw "$mnt"
 mounted=1
 sudo mount --bind /dev "$mnt/dev"
 sudo mount -t proc proc "$mnt/proc"
@@ -185,7 +200,7 @@ for d in dev proc sys; do
     umount_retry "$mnt/$d"
 done
 for _ in 1 2 3 4 5; do
-    sudo guestunmount "$mnt" && break
+    sudo_guestfs guestunmount "$mnt" && break
     sleep 1
 done
 mounted=0


### PR DESCRIPTION
blktests-ci boots these containerDisks as test VMs and provisions them with a cloud-init script that installs sudo, podman, jq, nvme-cli, sg3_utils and lsscsi if they are missing.

Add a kubevirt-runner bundle with exactly that tooling and inject it into every containerDisk on top of the variant's own bundle, so both nvmetcli and blktests disks come up ready. The package lists are deduplicated, so blktests (which already carried jq, nvme-cli and sg3_utils) only gains sudo, podman and lsscsi.

Additionally, from local testing a build fix was applied: sudo scrubbed the environment, so an exported LIBGUESTFS_BACKEND or LIBGUESTFS_HV never reached guestmount. Forward them explicitly.